### PR TITLE
Implement user-role-permission schema with Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # lms_nelms
 attempt for create lms
+
+## Database Setup
+
+Alembic migrations are stored in the `alembic` folder. To initialize the test SQLite database and apply migrations run:
+
+```bash
+alembic upgrade head
+```
+
+To seed base roles run:
+
+```bash
+python seed_roles.py
+```
+
+An ER diagram of auth related tables is available in `docs/erd_auth.mmd`.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,49 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+from alembic import context
+import os
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+from app.models.auth import Base  # noqa
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/20250615_075945_create_auth_tables.py
+++ b/alembic/versions/20250615_075945_create_auth_tables.py
@@ -1,0 +1,66 @@
+"""create auth tables
+
+Revision ID: create_auth_tables
+Revises: 
+Create Date: 2024-05-30
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'create_auth_tables'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'users',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('email', sa.String(length=255), nullable=False),
+        sa.Column('phone', sa.String(length=20), nullable=True),
+        sa.Column('hashed_password', sa.String(length=255), nullable=False),
+        sa.Column('first_name', sa.String(length=100), nullable=True),
+        sa.Column('last_name', sa.String(length=100), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index('ix_users_email', 'users', ['email'], unique=True)
+    op.create_index('ix_users_phone', 'users', ['phone'], unique=True)
+
+    op.create_table(
+        'roles',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('slug', sa.String(length=50), nullable=False, unique=True),
+        sa.Column('title', sa.String(length=100), nullable=False),
+    )
+
+    op.create_table(
+        'permissions',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('code', sa.String(length=50), nullable=False, unique=True),
+        sa.Column('description', sa.String(length=255), nullable=True),
+    )
+
+    op.create_table(
+        'user_roles',
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('role_id', sa.Integer, sa.ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True),
+    )
+
+    op.create_table(
+        'role_permissions',
+        sa.Column('role_id', sa.Integer, sa.ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('permission_id', sa.Integer, sa.ForeignKey('permissions.id', ondelete='CASCADE'), primary_key=True),
+    )
+
+def downgrade():
+    op.drop_table('role_permissions')
+    op.drop_table('user_roles')
+    op.drop_table('permissions')
+    op.drop_table('roles')
+    op.drop_index('ix_users_email', table_name='users')
+    op.drop_index('ix_users_phone', table_name='users')
+    op.drop_table('users')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -1,0 +1,58 @@
+import uuid
+from datetime import datetime
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Table, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from . import Base
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String(255), unique=True, nullable=False)
+    phone = Column(String(20), unique=True, nullable=True)
+    hashed_password = Column(String(255), nullable=False)
+    first_name = Column(String(100), nullable=True)
+    last_name = Column(String(100), nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    roles = relationship('Role', secondary='user_roles', back_populates='users')
+
+
+class Role(Base):
+    __tablename__ = 'roles'
+
+    id = Column(Integer, primary_key=True)
+    slug = Column(String(50), unique=True, nullable=False)
+    title = Column(String(100), nullable=False)
+
+    users = relationship('User', secondary='user_roles', back_populates='roles')
+    permissions = relationship('Permission', secondary='role_permissions', back_populates='roles')
+
+
+class Permission(Base):
+    __tablename__ = 'permissions'
+
+    id = Column(Integer, primary_key=True)
+    code = Column(String(50), unique=True, nullable=False)
+    description = Column(String(255), nullable=True)
+
+    roles = relationship('Role', secondary='role_permissions', back_populates='permissions')
+
+
+user_roles = Table(
+    'user_roles',
+    Base.metadata,
+    Column('user_id', UUID(as_uuid=True), ForeignKey('users.id', ondelete='CASCADE'), primary_key=True),
+    Column('role_id', Integer, ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True),
+)
+
+role_permissions = Table(
+    'role_permissions',
+    Base.metadata,
+    Column('role_id', Integer, ForeignKey('roles.id', ondelete='CASCADE'), primary_key=True),
+    Column('permission_id', Integer, ForeignKey('permissions.id', ondelete='CASCADE'), primary_key=True),
+)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from uuid import UUID
+from pydantic import BaseModel, EmailStr
+from typing import Optional, List
+
+class PermissionRead(BaseModel):
+    id: int
+    code: str
+    description: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+class RoleRead(BaseModel):
+    id: int
+    slug: str
+    title: str
+    permissions: List[PermissionRead] = []
+
+    class Config:
+        orm_mode = True
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    phone: Optional[str]
+    password: str
+    first_name: Optional[str]
+    last_name: Optional[str]
+
+class UserRead(BaseModel):
+    id: UUID
+    email: EmailStr
+    phone: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    is_active: bool
+    roles: List[RoleRead] = []
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/docs/erd_auth.mmd
+++ b/docs/erd_auth.mmd
@@ -1,0 +1,36 @@
+```mermaid
+erDiagram
+    users {
+        UUID id PK
+        string email
+        string phone
+        string hashed_password
+        string first_name
+        string last_name
+        boolean is_active
+        datetime created_at
+        datetime updated_at
+    }
+    roles {
+        int id PK
+        string slug
+        string title
+    }
+    permissions {
+        int id PK
+        string code
+        string description
+    }
+    user_roles {
+        UUID user_id FK
+        int role_id FK
+    }
+    role_permissions {
+        int role_id FK
+        int permission_id FK
+    }
+    users ||--o{ user_roles : ""
+    roles ||--o{ user_roles : ""
+    roles ||--o{ role_permissions : ""
+    permissions ||--o{ role_permissions : ""
+```

--- a/seed_roles.py
+++ b/seed_roles.py
@@ -1,0 +1,24 @@
+"""Seed script to create base roles."""
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from app.models.auth import Base, Role
+from sqlalchemy import create_engine
+
+engine = create_engine('sqlite:///./test.db')
+
+Base.metadata.create_all(engine)
+
+roles = [
+    {'slug': 'student', 'title': 'Student'},
+    {'slug': 'parent', 'title': 'Parent'},
+    {'slug': 'teacher', 'title': 'Teacher'},
+    {'slug': 'manager', 'title': 'Manager'},
+    {'slug': 'admin', 'title': 'Admin'},
+]
+
+with Session(engine) as session:
+    for role in roles:
+        exists = session.query(Role).filter_by(slug=role['slug']).first()
+        if not exists:
+            session.add(Role(**role))
+    session.commit()


### PR DESCRIPTION
## Summary
- add Alembic environment and initial migration creating users/roles/permissions tables
- implement SQLAlchemy models and Pydantic schemas
- create seed script for base roles
- provide ER diagram in Mermaid format
- document how to run migrations and seeds

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e7d31c0748324b5c1b5d04d4cc8fd